### PR TITLE
Switch to upload.php

### DIFF
--- a/gyazowin/gyazowin.cpp
+++ b/gyazowin/gyazowin.cpp
@@ -792,7 +792,7 @@ BOOL saveId(const WCHAR* str)
 BOOL uploadFile(HWND hwnd, LPCTSTR fileName)
 {
 	const TCHAR* UPLOAD_SERVER	= _T("pomf.se");
-	const TCHAR* UPLOAD_PATH = _T("upload.php?output=urls");
+	const TCHAR* UPLOAD_PATH = _T("upload.php?output=gyazo");
 
 	const char*  sBoundary = "----BOUNDARYBOUNDARY----";		// boundary
 	const char   sCrLf[]   = { 0xd, 0xa, 0x0 };					// 改行(CR+LF)


### PR DESCRIPTION
Since `upload.php?output=gyazo` now returns the URL of the first file, switching from `blackniggers/kittens.php` should be fairly easy.

This moves the endpoint, changes the multipart form data to upload the `files` field with a filename of `image.png`, and uncomments the `Content-Type` HTTP Header lines, which will be important in future, as we'll eventually be relying on that instead of file extensions.
